### PR TITLE
Move ApplicationInsightsExtensions to Microsoft.Framework.DependencyInjection

### DIFF
--- a/src/Microsoft.ApplicationInsights.AspNet/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNet/Extensions/ApplicationInsightsExtensions.cs
@@ -1,7 +1,9 @@
-﻿namespace Microsoft.ApplicationInsights.AspNet
+﻿namespace Microsoft.Framework.DependencyInjection
 {
     using System;
     using System.Collections.Generic;
+    using Microsoft.ApplicationInsights;
+    using Microsoft.ApplicationInsights.AspNet;
     using Microsoft.ApplicationInsights.AspNet.ContextInitializers;
     using Microsoft.ApplicationInsights.AspNet.TelemetryInitializers;
     using Microsoft.ApplicationInsights.Channel;
@@ -10,7 +12,6 @@
     using Microsoft.AspNet.Builder;
     using Microsoft.AspNet.Mvc.Rendering;
     using Microsoft.Framework.ConfigurationModel;
-    using Microsoft.Framework.DependencyInjection;
 
     public static class ApplicationInsightsExtensions
     {

--- a/test/Microsoft.ApplicationInsights.AspNet.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNet.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -1,17 +1,18 @@
-﻿namespace Microsoft.ApplicationInsights.AspNet.Tests
+﻿namespace Microsoft.Framework.DependencyInjection
 {
     using System;
     using System.IO;
     using System.Linq;
+    using Microsoft.ApplicationInsights;
     using Microsoft.ApplicationInsights.AspNet.ContextInitializers;
     using Microsoft.ApplicationInsights.AspNet.TelemetryInitializers;
+    using Microsoft.ApplicationInsights.AspNet.Tests;
     using Microsoft.ApplicationInsights.AspNet.Tests.Helpers;
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.AspNet.Builder;
     using Microsoft.AspNet.Hosting;
     using Microsoft.Framework.ConfigurationModel;
-    using Microsoft.Framework.DependencyInjection;
     using Xunit;
 
     public static class ApplicationInsightsExtensionsTests

--- a/test/Microsoft.ApplicationInsights.AspNet.Tests/Microsoft.ApplicationInsights.AspNet.Tests.xproj
+++ b/test/Microsoft.ApplicationInsights.AspNet.Tests/Microsoft.ApplicationInsights.AspNet.Tests.xproj
@@ -23,6 +23,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" />
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" />
 </Project>

--- a/test/SampleWebAppIntegration/SampleWebAppIntegration.xproj
+++ b/test/SampleWebAppIntegration/SampleWebAppIntegration.xproj
@@ -17,6 +17,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" />
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" />
 </Project>

--- a/test/SampleWebAppIntegration/Startup.cs
+++ b/test/SampleWebAppIntegration/Startup.cs
@@ -1,16 +1,13 @@
 ﻿using System;
 using FunctionalTestUtils;
-using Microsoft.ApplicationInsights.AspNet;
 using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.Diagnostics;
 using Microsoft.AspNet.Diagnostics.Entity;
 using Microsoft.AspNet.Hosting;
-using Microsoft.AspNet.Identity;
 using Microsoft.AspNet.Identity.EntityFramework;
 using Microsoft.Framework.ConfigurationModel;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.Logging;
-using Microsoft.Framework.Logging.Console;
 using SampleWebAppIntegration.Models;
 
 namespace SampleWebAppIntegration

--- a/test/SampleWebAppIntegration/Views/Shared/_Layout.cshtml
+++ b/test/SampleWebAppIntegration/Views/Shared/_Layout.cshtml
@@ -1,4 +1,4 @@
-﻿@using Microsoft.ApplicationInsights.AspNet
+﻿@using Microsoft.Framework.DependencyInjection
 @inject Microsoft.ApplicationInsights.DataContracts.RequestTelemetry RequestTelemetry 
 <!DOCTYPE html>
 <html>


### PR DESCRIPTION
For consistency with ASP.NET 5 APIs and project structure.
- Move ApplicationInsightsExtensions class to the Microsoft.Framework.DependencyInjections.
- Move ApplicationInsightsExtensions.cs file to the Extensions folder.

Related issue #24.