### PR TITLE
Make names of middleware classes shorter and more descriptive

### DIFF
--- a/src/Microsoft.ApplicationInsights.AspNet/ExceptionTrackingMiddleware.cs
+++ b/src/Microsoft.ApplicationInsights.AspNet/ExceptionTrackingMiddleware.cs
@@ -5,12 +5,12 @@
     using System;
     using System.Threading.Tasks;
 
-    public sealed class ApplicationInsightsExceptionMiddleware
+    public sealed class ExceptionTrackingMiddleware
     {
         private readonly RequestDelegate next;
         private readonly TelemetryClient telemetryClient;
 
-        public ApplicationInsightsExceptionMiddleware(RequestDelegate next, TelemetryClient client)
+        public ExceptionTrackingMiddleware(RequestDelegate next, TelemetryClient client)
         {
             this.next = next;
             this.telemetryClient = client;

--- a/src/Microsoft.ApplicationInsights.AspNet/ExceptionTrackingMiddleware.cs
+++ b/src/Microsoft.ApplicationInsights.AspNet/ExceptionTrackingMiddleware.cs
@@ -1,10 +1,13 @@
 ﻿namespace Microsoft.ApplicationInsights.AspNet
 {
-    using Microsoft.AspNet.Builder;
-    using Microsoft.AspNet.Http;
     using System;
     using System.Threading.Tasks;
+    using Microsoft.AspNet.Builder;
+    using Microsoft.AspNet.Http;
 
+    /// <summary>
+    /// Sends telemetry about exceptions thrown by the application to the Microsoft Application Insights service.
+    /// </summary>
     public sealed class ExceptionTrackingMiddleware
     {
         private readonly RequestDelegate next;

--- a/src/Microsoft.ApplicationInsights.AspNet/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNet/Extensions/ApplicationInsightsExtensions.cs
@@ -26,7 +26,7 @@
 
         public static IApplicationBuilder UseApplicationInsightsExceptionTelemetry(this IApplicationBuilder app)
         {
-            app.UseMiddleware<ApplicationInsightsExceptionMiddleware>();
+            app.UseMiddleware<ExceptionTrackingMiddleware>();
             return app;
         }
 

--- a/src/Microsoft.ApplicationInsights.AspNet/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNet/Extensions/ApplicationInsightsExtensions.cs
@@ -17,17 +17,12 @@
     {
         public static IApplicationBuilder UseApplicationInsightsRequestTelemetry(this IApplicationBuilder app)
         {
-            // TODO: Register if customer did not register
-            //app.UseRequestServices();
-
-            app.UseMiddleware<ApplicationInsightsRequestMiddleware>();
-            return app;
+            return app.UseMiddleware<RequestTrackingMiddleware>();
         }
 
         public static IApplicationBuilder UseApplicationInsightsExceptionTelemetry(this IApplicationBuilder app)
         {
-            app.UseMiddleware<ExceptionTrackingMiddleware>();
-            return app;
+            return app.UseMiddleware<ExceptionTrackingMiddleware>();
         }
 
         public static IApplicationBuilder SetApplicationInsightsTelemetryDeveloperMode(this IApplicationBuilder app)

--- a/src/Microsoft.ApplicationInsights.AspNet/RequestTrackingMiddleware.cs
+++ b/src/Microsoft.ApplicationInsights.AspNet/RequestTrackingMiddleware.cs
@@ -9,12 +9,12 @@
     using System.Diagnostics;
     using System.Threading.Tasks;
 
-    public sealed class ApplicationInsightsRequestMiddleware
+    public sealed class RequestTrackingMiddleware
     {
         private readonly RequestDelegate next;
         private readonly TelemetryClient telemetryClient;
         
-        public ApplicationInsightsRequestMiddleware(RequestDelegate next, TelemetryClient client)
+        public RequestTrackingMiddleware(RequestDelegate next, TelemetryClient client)
         {
             this.telemetryClient = client;
             this.next = next;

--- a/src/Microsoft.ApplicationInsights.AspNet/RequestTrackingMiddleware.cs
+++ b/src/Microsoft.ApplicationInsights.AspNet/RequestTrackingMiddleware.cs
@@ -1,14 +1,17 @@
 ﻿namespace Microsoft.ApplicationInsights.AspNet
 {
+    using System;
+    using System.Diagnostics;
+    using System.Threading.Tasks;
     using Microsoft.ApplicationInsights;
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.AspNet.Builder;
     using Microsoft.AspNet.Http;
     using Microsoft.Framework.DependencyInjection;
-    using System;
-    using System.Diagnostics;
-    using System.Threading.Tasks;
 
+    /// <summary>
+    /// Sends telemetry about requests handled by the application to the Microsoft Application Insights service.
+    /// </summary>
     public sealed class RequestTrackingMiddleware
     {
         private readonly RequestDelegate next;


### PR DESCRIPTION
To address issue #22, this change removes term "ApplicationInsights" from the names of our middleware classes because it already appears in the namespace. It also adds term "Tracking" to make middleware class names more descriptive.

