### PR TITLE
change references to point to RC packages

### DIFF
--- a/src/Microsoft.ApplicationInsights.AspNet/project.json
+++ b/src/Microsoft.ApplicationInsights.AspNet/project.json
@@ -2,7 +2,7 @@
     "title": "Application Insights for ASP.NET 5 Web Applications",
     "description": "Application Insights for ASP.NET 5 web applications. See http://go.microsoft.com/fwlink/?LinkID=510752 for more information.",
     "authors": [ "Microsoft" ],
-    "version": "0.30.0.1-beta",
+    "version": "0.31.0-beta4",
     "copyright": "Copyright © Microsoft. All Rights Reserved.",
     "projectUrl": "https://github.com/Microsoft/AppInsights-aspnetv5",
     "licenseUrl": "http://go.microsoft.com/fwlink/?LinkID=510709", 
@@ -10,12 +10,12 @@
     "iconUrl": "http://appanacdn.blob.core.windows.net/cdn/icons/aic.png",
     "tags": [ "Analytics", "ApplicationInsights", "Telemetry", "AppInsights" ],
     "dependencies": {
-        "Microsoft.AspNet.Hosting": "1.0.0-beta4-*",
-        "Microsoft.Framework.Logging": "1.0.0-beta4-*",
-        "Microsoft.AspNet.Http": "1.0.0-beta4-*",
-        "Microsoft.AspNet.Http.Extensions": "1.0.0-beta4-*",
-        "Microsoft.AspNet.Mvc.Core": "6.0.0-beta4-*",
-        "System.Net.NameResolution": "4.0.0-beta-*"
+        "Microsoft.AspNet.Hosting": "1.0.0-beta4",
+        "Microsoft.Framework.Logging": "1.0.0-beta4",
+        "Microsoft.AspNet.Http": "1.0.0-beta4",
+        "Microsoft.AspNet.Http.Extensions": "1.0.0-beta4",
+        "Microsoft.AspNet.Mvc.Core": "6.0.0-beta4",
+        "System.Net.NameResolution": "4.0.0-beta"
     },
 
     "frameworks": {


### PR DESCRIPTION
ASP.NET runtime packages dropped build number from packages version and our package will not work with the default Visual Studio RC installation. I propose to release a hotfix today that only changes references. Going forward we can try to drop MyGet from the list of NuGet sources completely.