### PR TITLE
measure startup time under debugger in Visual studio

### DIFF
--- a/ApplicationInsights.AspNet.sln
+++ b/ApplicationInsights.AspNet.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.22808.1
+VisualStudioVersion = 14.0.22823.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{2E6DDE9E-8C75-4F9C-8906-08EBDD6E73EF}"
 EndProject
@@ -23,6 +23,11 @@ EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "FunctionalTestUtils", "test\FunctionalTestUtils\FunctionalTestUtils.xproj", "{B7217A00-66FA-49A8-8EF3-39C07E1F7E33}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "WebApiShimFw46.FunctionalTests", "test\WebApiShimFw46.FunctionalTests\WebApiShimFw46.FunctionalTests.xproj", "{11FB2EE6-7199-4AFF-BC73-25F35675F233}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "StartupPerf", "StartupPerf", "{16B44D67-6214-4DDE-B419-93EF073E2E69}"
+	ProjectSection(SolutionItems) = preProject
+		test\StartupPerf\startupPerf.ps1 = test\StartupPerf\startupPerf.ps1
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -60,5 +65,6 @@ Global
 		{330152EC-1092-41F0-9F96-C3438E07FCC2} = {8B5230E5-8138-44D6-839F-DF9248F195EE}
 		{B7217A00-66FA-49A8-8EF3-39C07E1F7E33} = {8B5230E5-8138-44D6-839F-DF9248F195EE}
 		{11FB2EE6-7199-4AFF-BC73-25F35675F233} = {8B5230E5-8138-44D6-839F-DF9248F195EE}
+		{16B44D67-6214-4DDE-B419-93EF073E2E69} = {8B5230E5-8138-44D6-839F-DF9248F195EE}
 	EndGlobalSection
 EndGlobal

--- a/test/StartupPerf/startupPerf.ps1
+++ b/test/StartupPerf/startupPerf.ps1
@@ -1,0 +1,47 @@
+# execute this first: Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope Process -Confirm 
+
+function GetUrlStatusCode($url)
+{
+	$req = [system.Net.WebRequest]::Create($url)
+	try {
+		$res = $req.GetResponse()
+	} catch [System.Net.WebException] {
+		$res = $_.Exception.Response
+	}
+	return [int]$res.StatusCode
+}
+
+$totalTime = 0
+$attempts = 10
+
+function StartUnderDebugger()
+{
+	$script:sw = [system.diagnostics.stopwatch]::StartNew()
+
+	$dte.ExecuteCommand("Debug.Start");
+	#$dte.ExecuteCommand("Debug.StartWithoutDebugging");
+
+	$status = GetUrlStatusCode("http://localhost:54056/")
+	while ($status -ne 200)
+	{
+		$status = GetUrlStatusCode("http://localhost:54056/")
+	}
+
+	$script:sw.Stop()
+	$elapsed = $script:sw.Elapsed.TotalMilliseconds
+	Write-Host $elapsed 
+
+	$global:totalTime = $global:totalTime + $elapsed
+
+	$dte.ExecuteCommand("Debug.StopDebugging");
+}
+
+$i = 0
+while ($i -lt $attempts)
+{
+	StartUnderDebugger
+	$i = $i + 1
+}
+
+Write-Host "Total $attempts attempts"
+


### PR DESCRIPTION
I run it many times - typically times very similar. Worst I get out of two sequential runs is 0.4 sec:
```
	with AI	without AI	
	6903.4364	5701.4235	
	6285.2875	5988.7779	
	6400.6323	5757.9383	
	6109.9152	6126.5687	
	6283.0474	5906.7686	
	6237.337	5944.2693	
	6199.4625	6948.1886	
	6467.1623	5916.281	
	7070.9624	5805.3368	
	6397.2912	5813.8167	overhead:
avg:	6435.45342	5990.93694	444.51648

```