### PR TITLE
Enable automated CI build of ApplicaitonInsights.AspNet.sln

### DIFF
--- a/ApplicationInsights.AspNet.sln
+++ b/ApplicationInsights.AspNet.sln
@@ -7,6 +7,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{2E6DDE9E-8C7
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{62AD20FD-640F-4F99-94EF-96A7581F1CF9}"
 	ProjectSection(SolutionItems) = preProject
+		Common.targets = Common.targets
 		global.json = global.json
 		NuGet.config = NuGet.config
 		Readme.md = Readme.md

--- a/Common.targets
+++ b/Common.targets
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="RestorePackages" Condition="'$(BuildingInsideVisualStudio)' != 'true'"
+    DependsOnTargets="GetRuntimeToolingPathTarget" BeforeTargets="CoreCompile">
+    <PropertyGroup>
+      <Dnu>$(RuntimeToolingDirectory)\bin\dnu.cmd</Dnu>
+    </PropertyGroup>
+    <Exec Command="$(Dnu) restore" WorkingDirectory="$(MSBuildProjectDirectory)" />
+  </Target>
+</Project>

--- a/src/Microsoft.ApplicationInsights.AspNet/Microsoft.ApplicationInsights.AspNet.xproj
+++ b/src/Microsoft.ApplicationInsights.AspNet/Microsoft.ApplicationInsights.AspNet.xproj
@@ -19,4 +19,5 @@
     <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" />
+  <Import Project="..\..\Common.targets" />
 </Project>

--- a/test/FunctionalTestUtils/FunctionalTestUtils.xproj
+++ b/test/FunctionalTestUtils/FunctionalTestUtils.xproj
@@ -15,4 +15,5 @@
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" />
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" />
+  <Import Project="..\..\Common.targets" />
 </Project>

--- a/test/Microsoft.ApplicationInsights.AspNet.Tests/Microsoft.ApplicationInsights.AspNet.Tests.xproj
+++ b/test/Microsoft.ApplicationInsights.AspNet.Tests/Microsoft.ApplicationInsights.AspNet.Tests.xproj
@@ -28,4 +28,5 @@
   </ItemGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" />
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" />
+  <Import Project="..\..\Common.targets" />
 </Project>

--- a/test/Mvc6Framework45.FunctionalTests/Mvc6Framework45.FunctionalTests.xproj
+++ b/test/Mvc6Framework45.FunctionalTests/Mvc6Framework45.FunctionalTests.xproj
@@ -22,4 +22,5 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="..\..\Common.targets" />
 </Project>

--- a/test/Mvc6Framework45.FunctionalTests/package.json
+++ b/test/Mvc6Framework45.FunctionalTests/package.json
@@ -2,6 +2,8 @@
   "name": "ASP.NET",
   "version": "0.0.0",
   "devDependencies": {
+    "bower": "^1.4.1",
+    "flatten-packages": "^0.1.4",
     "gulp": "3.8.11",
     "rimraf": "2.2.8"
   }

--- a/test/Mvc6Framework45.FunctionalTests/project.json
+++ b/test/Mvc6Framework45.FunctionalTests/project.json
@@ -34,7 +34,7 @@
   "commands": {
     "web": "Microsoft.AspNet.Hosting --server Microsoft.AspNet.Server.WebListener --server.urls http://localhost:5000",
     "gen": "Microsoft.Framework.CodeGeneration",
-    "ef":  "EntityFramework.Commands"
+    "ef": "EntityFramework.Commands"
   },
 
   "frameworks": {
@@ -55,7 +55,13 @@
     "**.vspscc"
   ],
   "scripts": {
-    "postrestore": [ "npm install", "bower install" ],
-    "prepare": [ "gulp copy" ]
+    "postrestore": [
+      "npm install",
+      "node_modules/.bin/flatten-packages",
+      "node_modules/.bin/bower install"
+    ],
+    "prepare": [
+      "node_modules/.bin/gulp copy" 
+    ]
   }
 }

--- a/test/WebApiShimFw46.FunctionalTests/WebApiShimFw46.FunctionalTests.xproj
+++ b/test/WebApiShimFw46.FunctionalTests/WebApiShimFw46.FunctionalTests.xproj
@@ -19,4 +19,5 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="..\..\Common.targets" />
 </Project>


### PR DESCRIPTION
`msbuild ApplicationInsights.AspNet.sln` fails out of the box with Visual Studio 2015 RC when any of the NuGet packages are missing from the .dnx/packages cache. This pull request adds a custom MSBuild .targets file that executes `dnu` to restore the packages. 

This pull request also adds all build-time NPM dependencies to package.json, including Bower and Gulp, to enable their automatic installation on the CI server during build. 